### PR TITLE
Clone filters when expanding jobs

### DIFF
--- a/lib/Job.js
+++ b/lib/Job.js
@@ -293,6 +293,7 @@ Job.prototype.expandJobs = function expandJobs(partsOverride) {
         delete opts.tiles;
         delete opts.size;
         opts.zoom = zoom;
+        opts.filters = _.map(self.filters, _.clone); // Deep copy to update filter.zoom for each subjob
 
         // To split properly, calculate job size at this zoom level, and scale to the needed zoom
         this.iterateOverRanges(0, (idxFrom, idxBefore) => {


### PR DESCRIPTION
When using `checkZoom=-1` on multiple zoom levels, the `filter.zoom` value is updated once, and shared between all subjobs. 

Filters values should be cloned explicitly (`_.clone` is not a deep clone), so that `filter.zoom` is properly calculated for each zoom level.