### PR TITLE
Ignore error when a tile is out-of-bounds in fileparser

### DIFF
--- a/lib/Job.js
+++ b/lib/Job.js
@@ -293,7 +293,10 @@ Job.prototype.expandJobs = function expandJobs(partsOverride) {
         delete opts.tiles;
         delete opts.size;
         opts.zoom = zoom;
-        opts.filters = _.map(self.filters, _.clone); // Deep copy to update filter.zoom for each subjob
+        if (self.filters) {
+            // Deep copy to update filter.zoom for each subjob
+            opts.filters = _.map(self.filters, _.clone);
+        }
 
         // To split properly, calculate job size at this zoom level, and scale to the needed zoom
         this.iterateOverRanges(0, (idxFrom, idxBefore) => {

--- a/lib/fileParser.js
+++ b/lib/fileParser.js
@@ -89,7 +89,13 @@ function parseSourceFile(srcFile, zoomLevels, zoomLvlIndex, cleanupList) {
                             }
                         }
                     }
-                    return qidx.xyToIndex(assertInt(parts[1], lineInd), assertInt(parts[2], lineInd), zoom) + '\n';
+                    try {
+                        return qidx.xyToIndex(assertInt(parts[1], lineInd), assertInt(parts[2], lineInd), zoom) + '\n';
+                    } catch (err) {
+                        // Log and ignore xyToIndex error when a tile is out-of-bounds in file
+                        core.log('warn', err.message);
+                        return undefined;
+                    }
                 }))
                 .on('error', reject)
                 .pipe(fs.createWriteStream(outputFile))


### PR DESCRIPTION
In our use-case, expired tiles file (generated by imposm) may contain tiles with invalid indexes.
This PR suggests to catch such errors during file parsing, and process the valid tiles anyway.