### PR TITLE
Tilerator crash with Postgres Lock

### DIFF
--- a/lib/JobProcessor.js
+++ b/lib/JobProcessor.js
@@ -294,7 +294,7 @@ JobProcessor.prototype.jobProcessorAsync = function() {
                 return self.jobProcessorAsync();
             }).catch(Promise.TimeoutError, function(e) {
                 throw new Err("Tile processing timed out");
-            });;
+            });
         }
     });
 };

--- a/lib/JobProcessor.js
+++ b/lib/JobProcessor.js
@@ -28,7 +28,7 @@ module.exports = JobProcessor;
  * @param {?EventService} eventService service for emitting resource change events
  * @constructor
  */
-function JobProcessor(sources, kueJob, metrics, queue, eventService) {
+function JobProcessor(sources, kueJob, metrics, queue, eventService, tileTimeOut = null) {
     this.sources = sources;
     this.kueJob = kueJob;
     this.metrics = metrics;
@@ -37,6 +37,7 @@ function JobProcessor(sources, kueJob, metrics, queue, eventService) {
     this.isShuttingDown = false;
     this.minEstimateHrsToBreak = 2;
     this.disableReportAndRebalance = !queue;
+    this.tileTimeOut = tileTimeOut || false;
 
     let stats = kueJob.progress_data && kueJob.progress_data.index ? kueJob.progress_data : {
         itemsPerSec: 0,
@@ -276,12 +277,25 @@ JobProcessor.prototype.jobProcessorAsync = function() {
             return;
         }
         // generate tile and repeat
-        return self.processOneTileAsync(iterValue).then(() => {
-            if (self.isShuttingDown) {
-                throw new Err('Shutting down');
-            }
-            return self.jobProcessorAsync();
-        });
+        // if timeout is 0 or not specified, e.g. null, keep old behavior
+        if (!this.tileTimeOut){
+            return self.processOneTileAsync(iterValue).then(() => {
+                if (self.isShuttingDown) {
+                    throw new Err('Shutting down');
+                }
+                return self.jobProcessorAsync();
+            });
+        } else {
+            // set timeout for tile process in case mapnik get stucked
+            return self.processOneTileAsync(iterValue).timeout(this.tileTimeOut).then(() => {
+                if (self.isShuttingDown) {
+                    throw new Err('Shutting down');
+                }
+                return self.jobProcessorAsync();
+            }).catch(Promise.TimeoutError, function(e) {
+                throw new Err("Tile processing timed out");
+            });;
+        }
     });
 };
 

--- a/lib/JobProcessor.js
+++ b/lib/JobProcessor.js
@@ -28,7 +28,7 @@ module.exports = JobProcessor;
  * @param {?EventService} eventService service for emitting resource change events
  * @constructor
  */
-function JobProcessor(sources, kueJob, metrics, queue, eventService, tileTimeOut = null) {
+function JobProcessor(sources, kueJob, metrics, queue, eventService, tileTimeOut) {
     this.sources = sources;
     this.kueJob = kueJob;
     this.metrics = metrics;


### PR DESCRIPTION
Set a timeout for the promise that initiate a tile creation. The timeout
should be defined in the config.yaml

Blocks https://github.com/kartotherian/tilerator/pull/45

Bug: [T204047](https://phabricator.wikimedia.org/T204047)